### PR TITLE
Fix Codex release prep workflow args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.16.2 - 2026-03-15
+
+- remove the incompatible `--quiet` Codex CLI flag from the release-prep GitHub Actions template
+- add regression coverage so scaffolded release-prep workflows keep matching the current Codex action contract
+
 ## 0.16.1 - 2026-03-15
 
 - make `check-docs` ignore common local virtualenv and cache directories so healthy repos do not fail on vendored README files

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-maintainer-kit",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Turn a code repository into a contributor-friendly public project with clear GitHub workflows.",
   "type": "module",
   "bin": {

--- a/templates/base/.github/workflows/codex-release-prep.yml
+++ b/templates/base/.github/workflows/codex-release-prep.yml
@@ -73,7 +73,6 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: release-prompt.txt
-          codex-args: '["--quiet"]'
           output-file: release-plan.md
 
       - name: Upload release plan

--- a/test/scaffold.test.js
+++ b/test/scaffold.test.js
@@ -650,3 +650,23 @@ test("first-public-repo docs stay accurate for the core bundle", async () => {
   assert.match(startHere, /if this file is present/i);
   assert.match(workflow, /if your scaffold includes it/);
 });
+
+test("release prep workflow does not pass removed Codex CLI flags", async () => {
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "oss-maintainer-kit-"));
+
+  await initKit({
+    bundle: "full",
+    maintainerName: "Jane Doe",
+    preset: "first-public-repo",
+    repoName: "demo-repo",
+    targetDir,
+  });
+
+  const workflow = await readFile(
+    path.join(targetDir, ".github", "workflows", "codex-release-prep.yml"),
+    "utf8",
+  );
+
+  assert.doesNotMatch(workflow, /codex-args:/);
+  assert.match(workflow, /output-file: release-plan\.md/);
+});


### PR DESCRIPTION
Removes the incompatible `--quiet` Codex CLI flag from the release prep workflow, bumps the package to `0.16.2`, updates the changelog, and adds a regression test so the scaffolded template stays aligned with the current Codex action contract.